### PR TITLE
Add CI/CD workflows for deployment and production environments

### DIFF
--- a/.github/cd.yml
+++ b/.github/cd.yml
@@ -1,0 +1,83 @@
+name: Deployment
+
+on:
+  workflow_call:
+    inputs:
+      environment-name:
+        type: string
+        required: true
+      environment-url:
+        type: string
+        required: true
+      aws-region:
+        type: string
+        required: true
+    secrets:
+      GH_ACTIONS_ROLE_ARN:
+        required: true      
+      AWS_BUCKET:
+        required: true      
+      CLOUDFRONT_DISTRIBUTION:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: ${{ inputs.environment-name }}
+      url: ${{ inputs.environment-url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }} 
+          role-session-name: GithubActions
+          aws-region: ${{ inputs.aws-region }}
+          audience: sts.amazonaws.com
+          mask-aws-account-id: false
+      
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: "10.x"
+          
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: node-modules-
+
+      - name: Install NPM packages
+        run: npm install
+
+      - name: Build
+        run: npm run deploy
+      
+      - name: list build result
+        run: |
+          ls -al out/      
+
+      - name: S3 Upload
+        run: |
+          aws s3 sync --no-progress --quiet ./out/ s3://$AWS_BUCKET/
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+
+      - name: S3 Delete Old Deployment
+        run: |
+          aws s3 sync --no-progress --quiet --delete ./out/ s3://$AWS_BUCKET/
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+      
+      - name: Invalidate CloudFront
+        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION --paths '/*'
+        env:
+          CLOUDFRONT_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION }}

--- a/.github/production.yml
+++ b/.github/production.yml
@@ -1,0 +1,22 @@
+name: Production
+on:
+  release:
+    types:
+      - released
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cd:
+    name: Deployment to Production
+    uses: ./.github/workflows/cd.yml
+    with:
+      environment-name: production
+      environment-url: https://legacyrenderer.accredify.io/
+      aws-region: ap-southeast-1
+    secrets:
+      GH_ACTIONS_ROLE_ARN: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+      AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+      CLOUDFRONT_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,7 @@ import { PrintWatermark } from "../src/utils/PrintWatermark";
 const FramelessViewerPage = () => (
   <div style={{ position: "relative" }}>
     <Head>
-      <title>OpenCerts - Frameless Certificate Viewer</title>
+      <title>Accredify Legacy Template Renderer</title>
     </Head>
     <PrintWatermark />
     <FramelessViewerPageContainer />


### PR DESCRIPTION
This pull request introduces a new deployment workflow for production releases and updates the application branding. The main changes include adding reusable GitHub Actions workflow files for deployment, configuring a production release workflow, and updating the page title to reflect the new product branding.

**Deployment workflow setup:**

* Added a reusable deployment workflow in `.github/cd.yml` to automate build, S3 upload, and CloudFront invalidation steps using GitHub Actions and AWS.

**Production release configuration:**

* Created `.github/production.yml` to trigger deployments to production on new releases, passing environment details and secrets to the deployment workflow.

**Branding update:**

* Changed the page title in `pages/index.js` from "OpenCerts - Frameless Certificate Viewer" to "Accredify Legacy Template Renderer" to reflect updated branding.